### PR TITLE
Fix Ansible lint errors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 install_updates: true
 instance_wait_retry_limit: 300
 instance_wait_connection_timeout: 600
@@ -22,9 +21,9 @@ qemu_second_cdrom_device_bus_type: ide
 qemu_second_cdrom_device_bus_id: 3
 qemu_second_cdrom_device_bus_unit: 0
 
-local_administrator_password: ''
+local_administrator_password: ""
 local_account_username: ansible
-local_account_password: ''
+local_account_password: ""
 
 distro_name: rhel10
 iso_file_name: CentOS-Stream-10-latest-x86_64-dvd1.iso

--- a/tasks/datastore_iso_remove.yml
+++ b/tasks/datastore_iso_remove.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Remove ISO image
   block:
     - name: Remove ISO file from data_domain

--- a/tasks/datastore_upload.yml
+++ b/tasks/datastore_upload.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Validate file
   ansible.builtin.stat:
     path: "{{ playbook_dir }}/{{ temp_directory }}/linux_{{ distro_name }}_ks_autogen.iso"

--- a/tasks/export_ovf.yml
+++ b/tasks/export_ovf.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Export template to export domain
   ovirt.ovirt.ovirt_template:
     auth: "{{ ovirt_auth }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Obtain SSO token with using username/password credentials
   ovirt.ovirt.ovirt_auth:
     url: "{{ lookup('env', 'OVIRT_URL') | default(ovirt.url, true) }}"
@@ -17,14 +16,13 @@
 
 # remove existing template
 - name: Remove existing template
-  block:
-
-    - name: Include remove_template
-      ansible.builtin.include_tasks: remove_template.yml
-
   when:
     - template_force | bool
     - template_found | bool
+
+  block:
+    - name: Include remove_template
+      ansible.builtin.include_tasks: remove_template.yml
 
 - name: Main task block
   block:
@@ -46,12 +44,12 @@
     - name: Add host
       ansible.builtin.add_host:
         hostname: template_vm
-        ansible_host: '{{ template_vm_ip_address }}'
+        ansible_host: "{{ template_vm_ip_address }}"
         host_key_checking: false
         ansible_user: "{{ local_account_username }}"
         ansible_password: "{{ local_account_password }}"
         ansible_port: "{{ vm_ansible_port | default('22') }}"
-        ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null'
+        ansible_ssh_common_args: "-o UserKnownHostsFile=/dev/null"
         ansible_python_interpreter: auto
 
     - name: Run setup module

--- a/tasks/make_iso.yml
+++ b/tasks/make_iso.yml
@@ -5,13 +5,13 @@
       ansible.builtin.file:
         path: "{{ temp_directory }}/ks_iso"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Create ks.cfg file
       ansible.builtin.template:
         src: "{{ linux_ks_folder }}/ks.cfg.j2"
         dest: "{{ temp_directory }}/ks_iso/ks.cfg"
-        mode: '0644'
+        mode: "0644"
 
     - name: Create ISO
       ansible.builtin.command: >

--- a/tasks/preflight_check.yml
+++ b/tasks/preflight_check.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Get the datacenter name
   ovirt.ovirt.ovirt_datacenter_info:
     auth: "{{ ovirt_auth }}"
@@ -35,6 +34,10 @@
   register: template_info
 
 - name: Handle existing template
+  when:
+    - template_info.ovirt_templates is defined
+    - template_info.ovirt_templates | length > 0
+
   block:
     - name: Set template_found to true
       ansible.builtin.set_fact:
@@ -44,10 +47,6 @@
       ansible.builtin.fail:
         msg: "Existing template found on ovirt/rhv: {{ template.name }}"
       when: not template_force | bool
-  when:
-    - template_info.ovirt_templates is defined
-    - template_info.ovirt_templates | length > 0
-
 - name: Check ISO file on data domain
   ovirt.ovirt.ovirt_disk_info:
     auth: "{{ ovirt_auth }}"
@@ -68,5 +67,4 @@
     msg: "iso file ({{ iso_file_name }}) could not be found on the data domain and iso domain does not exists"
   when:
     - iso_file_id is undefined
-    - iso_domain is undefined or iso_domain | length == 0
     - iso_domain is undefined or iso_domain | length == 0

--- a/tasks/preflight_check_pre29.yml
+++ b/tasks/preflight_check_pre29.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Get the datacenter name (<2.9)
   community.general.ovirt_datacenter_facts:
     auth: "{{ ovirt_auth }}"
@@ -31,8 +30,11 @@
     auth: "{{ ovirt_auth }}"
     pattern: "name={{ template.name }} and datacenter={{ ovirt_datacenters[0].name }}"
 
-
 - name: Handle existing template (<2.9)
+  when:
+    - ovirt_templates is defined
+    - ovirt_templates | length > 0
+
   block:
     - name: Set template_found to true
       ansible.builtin.set_fact:
@@ -42,10 +44,6 @@
       ansible.builtin.fail:
         msg: "Existing template found on ovirt/rhv: {{ template.name }}"
       when: not template_force | bool
-  when:
-    - ovirt_templates is defined
-    - ovirt_templates | length > 0
-
 - name: Check ISO file on data domain (<2.9)
   community.general.ovirt_disk_facts:
     auth: "{{ ovirt_auth }}"
@@ -65,5 +63,4 @@
     msg: "iso file ({{ template.name }}) could not be found on the data domain and iso domain does not exists"
   when:
     - iso_file_id is undefined
-    - iso_domain is undefined or iso_domain | length == 0
     - iso_domain is undefined or iso_domain | length == 0

--- a/tasks/provision.yml
+++ b/tasks/provision.yml
@@ -1,116 +1,130 @@
 ---
+- name: Main provisioning block
+  block:
+    - name: Include make_iso.yml tasks
+      ansible.builtin.include_tasks: make_iso.yml
 
-- block:
-    - include_tasks: make_iso.yml
+    - name: Include provision_vm.yml tasks
+      ansible.builtin.include_tasks: provision_vm.yml
 
-    - include_tasks: provision_vm.yml
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory
 
-    - name: refresh inventory
-      meta: refresh_inventory
+    - name: Clear gathered facts
+      ansible.builtin.meta: clear_facts
 
-    - name: clear gathered facts
-      meta: clear_facts
+    - name: Clear any host errors
+      ansible.builtin.meta: clear_host_errors
 
-    - name: clear any host errors
-      meta: clear_host_errors
-
-    - name: add host
-      add_host:
+    - name: Add host
+      ansible.builtin.add_host:
         hostname: template_vm
-        ansible_host: '{{ template_vm_ip_address }}'
+        ansible_host: "{{ template_vm_ip_address }}"
         host_key_checking: false
         ansible_user: "{{ local_account_username }}"
         ansible_password: "{{ local_account_password }}"
         ansible_port: "{{ vm_ansible_port | default('22') }}"
-        ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null'
+        ansible_ssh_common_args: "-o UserKnownHostsFile=/dev/null"
         ansible_python_interpreter: auto
 
-    - name: run setup module
-      setup:
+    - name: Run setup module
+      ansible.builtin.setup:
       delegate_to: template_vm
       connection: ssh
 
-    - block:
-        - include_role:
+    - name: Role tasks execution block
+      block:
+        - name: Include oatakan.rhn role (register)
+          ansible.builtin.include_role:
             name: oatakan.rhn
             apply:
               delegate_to: template_vm
               connection: ssh
-              become: yes
+              become: true
+          vars:
+            rhel_ovirt_template_role_action: register
 
-        - include_role:
+        - name: Include oatakan.rhel_upgrade role
+          ansible.builtin.include_role:
             name: oatakan.rhel_upgrade
             apply:
               delegate_to: template_vm
               connection: ssh
-              become: yes
-          when: install_updates|bool
+              become: true
+          when: install_updates | bool
 
-        - include_role:
+        - name: Include oatakan.rhel_template_build role
+          ansible.builtin.include_role:
             name: oatakan.rhel_template_build
             apply:
               delegate_to: template_vm
               connection: ssh
-              become: yes
+              become: true
               vars:
-                target_ovirt: yes
-
+                target_ovirt: true
       always:
-        - include_role:
+        - name: Include oatakan.rhn role (unregister)
+          ansible.builtin.include_role:
             name: oatakan.rhn
             apply:
               delegate_to: template_vm
               connection: ssh
-              become: yes
+              become: true
           vars:
             role_action: unregister
 
-    - name: force handlers to run before stoppping the vm
-      meta: flush_handlers
+    - name: Force handlers to run before stoppping the vm
+      ansible.builtin.meta: flush_handlers
 
-    - name: refresh SSO credentials
+    - name: Refresh SSO credentials
       ovirt.ovirt.ovirt_auth:
-        url: "{{ lookup('env', 'OVIRT_URL')|default(ovirt.url, true) }}"
-        username: "{{ lookup('env', 'OVIRT_USERNAME')|default(ovirt.username, true) }}"
-        password: "{{ lookup('env', 'OVIRT_PASSWORD')|default(ovirt.password, true) }}"
-        insecure: yes
+        url: "{{ lookup('env', 'OVIRT_URL') | default(ovirt.url, true) }}"
+        username: "{{ lookup('env', 'OVIRT_USERNAME') | default(ovirt.username, true) }}"
+        password: "{{ lookup('env', 'OVIRT_PASSWORD') | default(ovirt.password, true) }}"
+        insecure: true
 
-    - include_tasks: stop_vm.yml
+    - name: Include stop_vm.yml tasks
+      ansible.builtin.include_tasks: stop_vm.yml
 
-    - include_tasks: convert_to_template.yml
+    - name: Include convert_to_template.yml tasks
+      ansible.builtin.include_tasks: convert_to_template.yml
 
-    - include_tasks: export_ovf.yml
-      when: export_ovf|bool
+    - name: Include export_ovf.yml tasks
+      ansible.builtin.include_tasks: export_ovf.yml
+      when: export_ovf | bool
 
   rescue:
-    - name: refresh SSO credentials
+    - name: Refresh SSO credentials (rescue)
       ovirt.ovirt.ovirt_auth:
-        url: "{{ lookup('env', 'OVIRT_URL')|default(ovirt.url, true) }}"
-        username: "{{ lookup('env', 'OVIRT_USERNAME')|default(ovirt.username, true) }}"
-        password: "{{ lookup('env', 'OVIRT_PASSWORD')|default(ovirt.password, true) }}"
-        insecure: yes
+        url: "{{ lookup('env', 'OVIRT_URL') | default(ovirt.url, true) }}"
+        username: "{{ lookup('env', 'OVIRT_USERNAME') | default(ovirt.username, true) }}"
+        password: "{{ lookup('env', 'OVIRT_PASSWORD') | default(ovirt.password, true) }}"
+        insecure: true
 
-    - include_tasks: remove_template.yml
-      when: remove_vm_on_error|bool
+    - name: Include remove_template.yml tasks (rescue)
+      ansible.builtin.include_tasks: remove_template.yml
+      when: remove_vm_on_error | bool
 
   always:
-    - name: refresh SSO credentials
+    - name: Refresh SSO credentials (always)
       ovirt.ovirt.ovirt_auth:
-        url: "{{ lookup('env', 'OVIRT_URL')|default(ovirt.url, true) }}"
-        username: "{{ lookup('env', 'OVIRT_USERNAME')|default(ovirt.username, true) }}"
-        password: "{{ lookup('env', 'OVIRT_PASSWORD')|default(ovirt.password, true) }}"
-        insecure: yes
+        url: "{{ lookup('env', 'OVIRT_URL') | default(ovirt.url, true) }}"
+        username: "{{ lookup('env', 'OVIRT_USERNAME') | default(ovirt.username, true) }}"
+        password: "{{ lookup('env', 'OVIRT_PASSWORD') | default(ovirt.password, true) }}"
+        insecure: true
 
-    - include_tasks: remove_vm.yml
+    - name: Include remove_vm.yml tasks (always)
+      ansible.builtin.include_tasks: remove_vm.yml
 
-    - include_tasks: datastore_iso_remove.yml
+    - name: Include datastore_iso_remove.yml tasks (always)
+      ansible.builtin.include_tasks: datastore_iso_remove.yml
 
-    - name: remove temporary directory
-      file:
+    - name: Remove temporary directory
+      ansible.builtin.file:
         path: "{{ temp_directory }}"
         state: absent
 
-    - name: logout from oVirt
+    - name: Logout from oVirt
       ovirt.ovirt.ovirt_auth:
         state: absent
         ovirt_auth: "{{ ovirt_auth }}"

--- a/tasks/provision_vm.yml
+++ b/tasks/provision_vm.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Provision a new VM
   ovirt.ovirt.ovirt_vm:
     auth: "{{ ovirt_auth }}"

--- a/tasks/remove_template.yml
+++ b/tasks/remove_template.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Remove template
   ovirt.ovirt.ovirt_template:
     auth: "{{ ovirt_auth }}"

--- a/tasks/remove_vm.yml
+++ b/tasks/remove_vm.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Remove VM
   ovirt.ovirt.ovirt_vm:
     auth: "{{ ovirt_auth }}"

--- a/tasks/stop_vm.yml
+++ b/tasks/stop_vm.yml
@@ -1,8 +1,6 @@
 ---
-
 - name: Stop VM tasks
   block:
-
     - name: Shutdown guest VM
       ovirt.ovirt.ovirt_vm:
         auth: "{{ ovirt_auth }}"

--- a/tasks/wait_disk_unlock.yml
+++ b/tasks/wait_disk_unlock.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait until the image is unlocked by the oVirt engine
   ovirt.ovirt.ovirt_disk_info:
     auth: "{{ ovirt_auth }}"

--- a/tasks/wait_disk_unlock_pre29.yml
+++ b/tasks/wait_disk_unlock_pre29.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait until the image is unlocked by the oVirt engine (<2.9)
   community.general.ovirt_disk_facts:
     auth: "{{ ovirt_auth }}"

--- a/tasks/wait_iso_disk_unlock.yml
+++ b/tasks/wait_iso_disk_unlock.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait until the disk is unlocked by the oVirt engine
   ovirt.ovirt.ovirt_disk_info:
     auth: "{{ ovirt_auth }}"

--- a/tasks/wait_iso_disk_unlock_pre29.yml
+++ b/tasks/wait_iso_disk_unlock_pre29.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait until the disk is unlocked by the oVirt engine (<2.9)
   community.general.ovirt_disk_facts:
     auth: "{{ ovirt_auth }}"

--- a/tasks/wait_vm_poweredoff.yml
+++ b/tasks/wait_vm_poweredoff.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait for VM status to be poweredoff
   ovirt.ovirt.ovirt_vm_info:
     auth: "{{ ovirt_auth }}"

--- a/tasks/wait_vm_poweredoff_pre29.yml
+++ b/tasks/wait_vm_poweredoff_pre29.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Wait for VM status to be poweredoff
   community.general.ovirt_vm_facts:
     auth: "{{ ovirt_auth }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: localhost
-  gather_facts: False
+- name: Test oatakan.rhel_ovirt_template role
+  hosts: localhost
+  gather_facts: false
   connection: local
-  become: no
+  become: false
   roles:
     - ../.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,12 +1,11 @@
 ---
-
 temp_directory: tmp{{ awx_job_id | default('') }}
 
 iso_file: "linux_{{ distro_name }}_ks{{ awx_job_id | default('') }}.iso"
 
 export_dir: "{{ playbook_dir }}/{{ temp_directory }}"
 
-remove_template: "{{ true if (role_action == 'deprovision' or template_force|bool) else false }}"
+remove_template: "{{ true if (role_action == 'deprovision' or template_force | bool) else false }}"
 
 providers:
   ovirt:


### PR DESCRIPTION
This commit addresses numerous Ansible lint errors throughout the role, including:
- Ensuring files end with a newline.
- Correcting YAML boolean representations (e.g., 'yes' to 'true').
- Adding names to tasks and plays where missing.
- Using Fully Qualified Collection Names (FQCN) for modules.
- Correcting Jinja spacing.
- Fixing YAML indentation and syntax.
- Removing duplicate 'when' conditions.

All YAML files now pass `ansible-lint` with no failures, except for one stylistic issue in `tests/test.yml`:
- `role-name[path]: Avoid using paths when importing roles. (../.)` This usage of `../.` is a common practice for self-contained role tests to ensure the role under test is correctly located. Changing it to the FQCN caused `syntax-check` failures in the linting environment as the role was not found in standard paths.

The `key-order[task]` rule was already skipped in the `.ansible-lint` configuration. Module load warnings during linting are due to the execution environment not having oVirt Ansible collections installed and do not affect YAML linting success.